### PR TITLE
Raised Exception when user plots drift map with minimal set to True

### DIFF
--- a/pydrift/core/drift_checker.py
+++ b/pydrift/core/drift_checker.py
@@ -603,6 +603,7 @@ class ModelDriftChecker(DriftChecker):
 
             `pydrift.InterpretableDrift.feature_importance_vs_drift_map_plot`
         """
+        if(not self.minimal): raise Exception("To plot drift map, set minimal argument to True when instantiating ModelDriftChecker") 
         data_drift_checker = DataDriftChecker(self.df_left_data,
                                               self.df_right_data,
                                               verbose=False,


### PR DESCRIPTION
`show_feature_importance_vs_drift_map_plot()`, Method does not check if the ModelDriftChecker is instantiated with minimal=True, because if its, then user can not plot this map
The Exception raised allows user to know why the code throws error when he/she wants to plot a drift map

_Suggestion_
- Let user pass 'minimal' argument for each of the functionalities provided by  ModelDriftChecker, So that user can decide for which of them user needs plot and for which user simply might want an output(without plots)
Doing so for every suitable/relevant feature is really helpful